### PR TITLE
Wrong import for defaults settings

### DIFF
--- a/stalker_pyramid/__init__.py
+++ b/stalker_pyramid/__init__.py
@@ -158,7 +158,7 @@ def main(global_config, **settings):
     )
 
     # before anything about stalker create the defaults
-    from stalker.config import defaults
+    from stalker import defaults
     logger.debug(
         os.path.normpath(
             defaults.server_side_storage_path + '/{partial_file_path}'


### PR DESCRIPTION
Fix error: ImportError: cannot import name 'defaults'
We just need to change the import line without the .config